### PR TITLE
Feat/delete event

### DIFF
--- a/backend/src/main/java/com/harmonical/backend/application/use_cases/DeleteEventUseCase.java
+++ b/backend/src/main/java/com/harmonical/backend/application/use_cases/DeleteEventUseCase.java
@@ -1,11 +1,34 @@
 package com.harmonical.backend.application.use_cases;
 
+import com.harmonical.backend.domain.exception.InvalidIDFormatException;
+import com.harmonical.backend.domain.exception.ResourceNotFoundException;
+import com.harmonical.backend.domain.port.EventRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 public class DeleteEventUseCase {
 
-    public void execute(String eventId) {
+    private final EventRepository eventRepository;
 
+    public DeleteEventUseCase(EventRepository eventRepository) {
+        this.eventRepository = eventRepository;
+    }
+
+    public void execute(String eventId) {
+        try {
+            UUID uuid = UUID.fromString(eventId);
+
+            eventRepository.findById(uuid)
+                    .ifPresentOrElse(
+                            eventRepository::delete,
+                            () -> {
+                                throw new ResourceNotFoundException("Event not found with id: " + eventId);
+                            }
+                    );
+        } catch (IllegalArgumentException e) {
+            throw new InvalidIDFormatException("Invalid ID format: " + eventId);
+        }
     }
 }

--- a/backend/src/main/java/com/harmonical/backend/application/use_cases/DeleteEventUseCase.java
+++ b/backend/src/main/java/com/harmonical/backend/application/use_cases/DeleteEventUseCase.java
@@ -1,0 +1,11 @@
+package com.harmonical.backend.application.use_cases;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class DeleteEventUseCase {
+
+    public void execute(String eventId) {
+
+    }
+}

--- a/backend/src/main/java/com/harmonical/backend/domain/exception/InvalidIDFormatException.java
+++ b/backend/src/main/java/com/harmonical/backend/domain/exception/InvalidIDFormatException.java
@@ -1,0 +1,7 @@
+package com.harmonical.backend.domain.exception;
+
+public class InvalidIDFormatException extends RuntimeException {
+    public InvalidIDFormatException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/harmonical/backend/domain/port/EventRepository.java
+++ b/backend/src/main/java/com/harmonical/backend/domain/port/EventRepository.java
@@ -11,4 +11,6 @@ public interface EventRepository {
     Optional<IEvent> findById(UUID eventId);
 
     List<IEvent> findAll(String search, LocalDate beginDate, LocalDate endDate);
+
+    void delete(IEvent event);
 }

--- a/backend/src/main/java/com/harmonical/backend/infrastructure/persistence/adapter/EventRepositoryAdapter.java
+++ b/backend/src/main/java/com/harmonical/backend/infrastructure/persistence/adapter/EventRepositoryAdapter.java
@@ -54,4 +54,9 @@ public class EventRepositoryAdapter implements EventRepository {
                 .map(mapper::toDomain)
                 .toList();
     }
+
+    @Override
+    public void delete(IEvent event) {
+        jpaEventRepository.deleteById(event.getId());
+    }
 }

--- a/backend/src/main/java/com/harmonical/backend/web/controller/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/harmonical/backend/web/controller/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.harmonical.backend.web.controller;
 
 import com.harmonical.backend.domain.exception.InvalidDateFormatException;
+import com.harmonical.backend.domain.exception.InvalidIDFormatException;
 import com.harmonical.backend.domain.exception.ResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidDateFormatException.class)
     public ResponseEntity<Map<String, String>> handleInvalidDateFormatException(InvalidDateFormatException e) {
+        return ResponseEntity
+                .badRequest()
+                .body(Map.of("message", e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidIDFormatException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidIDFormatException(InvalidIDFormatException e) {
         return ResponseEntity
                 .badRequest()
                 .body(Map.of("message", e.getMessage()));

--- a/backend/src/main/java/com/harmonical/backend/web/controller/event/DeleteEvent.java
+++ b/backend/src/main/java/com/harmonical/backend/web/controller/event/DeleteEvent.java
@@ -1,0 +1,26 @@
+package com.harmonical.backend.web.controller.event;
+
+import com.harmonical.backend.application.use_cases.DeleteEventUseCase;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/events")
+public class DeleteEvent {
+
+    private final DeleteEventUseCase deleteEventUseCase;
+
+    public DeleteEvent(DeleteEventUseCase deleteEventUseCase) {
+        this.deleteEventUseCase = deleteEventUseCase;
+    }
+
+    @DeleteMapping("/{eventId}")
+    public ResponseEntity<Void> deleteEvent(@PathVariable String eventId) {
+        deleteEventUseCase.execute(eventId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/test/java/com/harmonical/backend/web/controller/event/DeleteEventTest.java
+++ b/backend/src/test/java/com/harmonical/backend/web/controller/event/DeleteEventTest.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -75,15 +73,28 @@ class DeleteEventTest {
     @DisplayName("When: An invalid event ID is provided")
     @Nested
     class InvalidEventId {
-        @DisplayName("Then: A 404 status is returned")
-        @ParameterizedTest
-        @ValueSource(strings = {"invalid-id", ""})
-        void testDeleteEvent(String eventId) {
+        @DisplayName("Then: A 404 status is returned when the format is invalid")
+        @Test
+        void testDeleteEventWithInvalidId() {
+            // Invalid ID format
             webTestClient.delete()
-                    .uri(getBaseUrl() + "/" + eventId)
+                    .uri(getBaseUrl() + "/invalid-id")
                     .exchange()
-                    .expectStatus().isNotFound();
+                    .expectStatus().isBadRequest()
+                    .expectBody()
+                    .jsonPath("$.message").isEqualTo("Invalid ID format: invalid-id");
         }
 
+        @DisplayName("Then: A 404 status is returned when the event does not exist")
+        @Test
+        void testDeleteEventWithNonExistentId() {
+            // Event does not exist
+            webTestClient.delete()
+                    .uri(getBaseUrl() + "/00000000-0000-0000-0000-000000000000")
+                    .exchange()
+                    .expectStatus().isNotFound()
+                    .expectBody()
+                    .jsonPath("$.message").isEqualTo("Event not found with id: 00000000-0000-0000-0000-000000000000");
+        }
     }
 }

--- a/backend/src/test/java/com/harmonical/backend/web/controller/event/DeleteEventTest.java
+++ b/backend/src/test/java/com/harmonical/backend/web/controller/event/DeleteEventTest.java
@@ -1,0 +1,89 @@
+package com.harmonical.backend.web.controller.event;
+
+import com.harmonical.backend.domain.model.Event;
+import com.harmonical.backend.domain.port.EventRepository;
+import com.harmonical.backend.domain.port.IEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@DisplayName("Given: A request to delete an event")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+class DeleteEventTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    private String getBaseUrl() {
+        return "http://localhost:" + port + "/api/events";
+    }
+
+    @DisplayName("When: A valid event ID is provided")
+    @Nested
+    class ValidEventId {
+
+        private IEvent savedEvent;
+
+        @BeforeEach
+        void setUp() {
+            this.savedEvent = eventRepository.save(new Event(
+                    "Test Event",
+                    "Test Description",
+                    LocalDate.now().plusDays(1),
+                    LocalTime.NOON,
+                    Duration.ofHours(2),
+                    "Test Location"
+            ));
+        }
+
+        @Test
+        @DisplayName("Then: The event is deleted")
+        void testDeleteEvent() {
+            webTestClient.delete()
+                    .uri(getBaseUrl() + "/" + savedEvent.getId())
+                    .exchange()
+                    .expectStatus().isNoContent();
+
+            assertFalse(eventRepository.findById(savedEvent.getId()).isPresent());
+        }
+
+    }
+
+    @DisplayName("When: An invalid event ID is provided")
+    @Nested
+    class InvalidEventId {
+        @DisplayName("Then: A 404 status is returned")
+        @ParameterizedTest
+        @ValueSource(strings = {"invalid-id", ""})
+        void testDeleteEvent(String eventId) {
+            webTestClient.delete()
+                    .uri(getBaseUrl() + "/" + eventId)
+                    .exchange()
+                    .expectStatus().isNotFound();
+        }
+
+    }
+}


### PR DESCRIPTION
This update introduces the functionality to delete events in the application, along with comprehensive tests to ensure its correctness. The main components of this feature include:

- **DeleteEventUseCase**: A service class that encapsulates the logic to delete an event given its ID. It validates the ID format, checks if the event exists, and then proceeds with the deletion. If the event does not exist or the ID format is invalid, it throws appropriate exceptions.

- **DeleteEvent Controller**: A REST controller that exposes an endpoint to delete events. It uses the `DeleteEventUseCase` to perform the deletion operation and returns a 204 No Content status upon successful deletion.

- **GlobalExceptionHandler Enhancements**: The global exception handler is updated to handle `InvalidIDFormatException`, ensuring that a meaningful error response is returned to the client when an invalid ID format is provided.

- **EventRepository Interface Update**: The `EventRepository` interface is extended to include a `delete` method, allowing for the deletion of events from the repository.

- **EventRepositoryAdapter Implementation**: Implements the `delete` method in `EventRepositoryAdapter`, which interacts with the underlying JPA repository to perform the deletion operation.

- **InvalidIDFormatException**: A new exception class to represent errors related to invalid event ID formats.

- **DeleteEventTest**: A test class that verifies the delete event functionality. It includes tests for both valid and invalid event IDs, ensuring the system behaves as expected in both scenarios. This includes checking for the correct HTTP status codes and validating that events are properly deleted when valid IDs are provided.

This feature enhances the application by allowing users to delete events, improving the overall event management capabilities. The included tests ensure the feature's reliability and correctness.